### PR TITLE
Update propery definition versions to accomodate the change of introducing optimization_type

### DIFF
--- a/schemas/src/defs/v1.2/entrytypes/optimade/structures.yaml
+++ b/schemas/src/defs/v1.2/entrytypes/optimade/structures.yaml
@@ -1,0 +1,213 @@
+$$schema: "https://schemas.optimade.org/meta/v1.2/optimade/entrytype_definition"
+$id: "https://schemas.optimade.org/defs/v1.2/entrytypes/optimade/structures"
+title: "structures"
+description: "The structures entry type describes a crystal structure via its unit cell"
+x-optimade-definition:
+  label: "structures_entrytype_optimade"
+  kind: "entrytype"
+  format: "1.2"
+  version: "1.2.0"
+  name: "structures"
+type: object
+properties:
+  id:
+    $$inherit: "/v1.2/properties/optimade/structures/id"
+    x-optimade-requirements:
+      support: "must"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "always"
+
+  type:
+    $$inherit: "/v1.2/properties/optimade/structures/type"
+    x-optimade-requirements:
+      support: "must"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "always"
+
+  immutable_id:
+    $$inherit: "/v1.2/properties/optimade/structures/immutable_id"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "may"
+
+  last_modified:
+    $$inherit: "/v1.2/properties/optimade/structures/last_modified"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "must"
+
+  elements:
+    $$inherit: "/v1.2/properties/optimade/structures/elements"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "may"
+
+  nelements:
+    $$inherit: "/v1.2/properties/optimade/structures/nelements"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "may"
+
+  elements_ratios:
+    $$inherit: "/v1.2/properties/optimade/structures/elements_ratios"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "may"
+
+  chemical_formula_descriptive:
+    $$inherit: "/v1.2/properties/optimade/structures/chemical_formula_descriptive"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "all mandatory"
+      response-level: "may"
+
+  chemical_formula_reduced:
+    $$inherit: "/v1.2/properties/optimade/structures/chemical_formula_reduced"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "equality only"
+      response-level: "may"
+      $comment: "If the database store chemical formulas in another format, it may not be possible to search efficiently for anything except equality."
+
+  chemical_formula_hill:
+    $$inherit: "/v1.2/properties/optimade/structures/chemical_formula_hill"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  chemical_formula_anonymous:
+    $$inherit: "/v1.2/properties/optimade/structures/chemical_formula_anonymous"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      query-support: "equality only"
+      response-level: "may"
+      $comment: "If the database store chemical formulas in another format, it may not be possible to search efficiently for anything except equality."
+
+  dimension_types:
+    $$inherit: "/v1.2/properties/optimade/structures/dimension_types"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  nperiodic_dimensions:
+    $$inherit: "/v1.2/properties/optimade/structures/nperiodic_dimensions"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "all mandatory"
+
+  lattice_vectors:
+    $$inherit: "/v1.2/properties/optimade/structures/lattice_vectors"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  space_group_symmetry_operations_xyz:
+    $$inherit: "/v1.2/properties/optimade/structures/space_group_symmetry_operations_xyz"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  space_group_symbol_hall:
+    $$inherit: "/v1.2/properties/optimade/structures/space_group_symbol_hall"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  space_group_symbol_hermann_mauguin:
+    $$inherit: "/v1.2/properties/optimade/structures/space_group_symbol_hermann_mauguin"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  space_group_symbol_hermann_mauguin_extended:
+    $$inherit: "/v1.2/properties/optimade/structures/space_group_symbol_hermann_mauguin_extended"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  space_group_it_number:
+    $$inherit: "/v1.2/properties/optimade/structures/space_group_it_number"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  cartesian_site_positions:
+    $$inherit: "/v1.2/properties/optimade/structures/cartesian_site_positions"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  nsites:
+    $$inherit: "/v1.2/properties/optimade/structures/nsites"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "all mandatory"
+
+  species_at_sites:
+    $$inherit: "/v1.2/properties/optimade/structures/species_at_sites"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  species:
+    $$inherit: "/v1.2/properties/optimade/structures/species"
+    x-optimade-requirements:
+      support: "should"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  assemblies:
+    $$inherit: "/v1.2/properties/optimade/structures/assemblies"
+    x-optimade-requirements:
+      support: "may"
+      sortable: false
+      response-level: "may"
+      query-support: "none"
+
+  structure_features:
+    $$inherit: "/v1.2/properties/optimade/structures/structure_features"
+    x-optimade-requirements:
+      support: "must"
+      sortable: false
+      response-level: "may"
+      query-support: "all mandatory"

--- a/schemas/src/defs/v1.2/standards/optimade.yaml
+++ b/schemas/src/defs/v1.2/standards/optimade.yaml
@@ -1,0 +1,23 @@
+$$schema: "https://schemas.optimade.org/meta/v1.2/optimade/standard_definition"
+$id: "https://schemas.optimade.org/defs/v1.2/standards/optimade"
+title: "OPTIMADE standard"
+description: "The OPTIMADE standard node types and properties"
+x-optimade-definition:
+  label: "optimade_standard"
+  kind: "standard"
+  format: "1.2"
+  version: "1.2.0"
+  name: "optimade"
+entrytypes:
+  structures:
+    $$inherit: "/v1.2/entrytypes/optimade/structures"
+    x-optimade-requirements:
+      support: "must"
+  files:
+    $$inherit: "/v1.2/entrytypes/optimade/files"
+    x-optimade-requirements:
+      support: "may"
+  references:
+    $$inherit: "/v1.2/entrytypes/optimade/references"
+    x-optimade-requirements:
+      support: "may"

--- a/schemas/src/defs/v1.3/entrytypes/optimade/structures.yaml
+++ b/schemas/src/defs/v1.3/entrytypes/optimade/structures.yaml
@@ -1,12 +1,12 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/entrytype_definition"
-$id: "https://schemas.optimade.org/defs/v1.2/entrytypes/optimade/structures"
+$id: "https://schemas.optimade.org/defs/v1.3/entrytypes/optimade/structures"
 title: "structures"
 description: "The structures entry type describes a crystal structure via its unit cell"
 x-optimade-definition:
   label: "structures_entrytype_optimade"
   kind: "entrytype"
   format: "1.2"
-  version: "1.2.0"
+  version: "1.3.0"
   name: "structures"
 type: object
 properties:
@@ -213,7 +213,7 @@ properties:
       query-support: "all mandatory"
 
   optimization_type:
-    $$inherit: "/v1.2/properties/optimade/structures/optimization_type"
+    $$inherit: "/v1.3/properties/optimade/structures/optimization_type"
     x-optimade-requirements:
       support: "may"
       sortable: false

--- a/schemas/src/defs/v1.3/properties/optimade/structures/optimization_type.yaml
+++ b/schemas/src/defs/v1.3/properties/optimade/structures/optimization_type.yaml
@@ -1,11 +1,11 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
-$id: "https://schemas.optimade.org/defs/v1.2/properties/optimade/structures/optimization_type"
+$id: "https://schemas.optimade.org/defs/v1.3/properties/optimade/structures/optimization_type"
 title: "Optimization type"
 x-optimade-type: "string"
 x-optimade-definition:
   label: "optimization_type_optimade_structures"
   kind: "property"
-  version: "1.2.0"
+  version: "1.3.0"
   format: "1.2"
   name: "optimization_type"
 type:

--- a/schemas/src/defs/v1.3/standards/optimade.yaml
+++ b/schemas/src/defs/v1.3/standards/optimade.yaml
@@ -1,16 +1,16 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/standard_definition"
-$id: "https://schemas.optimade.org/defs/v1.2/standards/optimade"
+$id: "https://schemas.optimade.org/defs/v1.3/standards/optimade"
 title: "OPTIMADE standard"
 description: "The OPTIMADE standard node types and properties"
 x-optimade-definition:
   label: "optimade_standard"
   kind: "standard"
   format: "1.2"
-  version: "1.2.0"
+  version: "1.3.0"
   name: "optimade"
 entrytypes:
   structures:
-    $$inherit: "/v1.2/entrytypes/optimade/structures"
+    $$inherit: "/v1.3/entrytypes/optimade/structures"
     x-optimade-requirements:
       support: "must"
   files:


### PR DESCRIPTION
This is at least how I had intended we'd handle versioning of the properties. Since we are now working on OPTIMADE v1.3.0~develop, i.e., we intend to release changed definitions as v1.3.0 (to keep versions in lockstep with OPTIMADE releases) new definitions that will release as part of that version of OPTIMADE are versioned v1.3.0, with corresponding IRI:s (in the `$id` schema field). Adding a new field to `structures` is a not a backwards-breaking change, but a feature addition, so also the entrytype and standard definitions are affected and thus bumped to `v1.3.0`.

Note that we also need to keep the v1.2 versions around as the latest patch versions of those versions, in case other providers' definition files refer to them. (E.g., they extend the v1.2 structures entry rather than the v1.3 one)